### PR TITLE
fix for fact__changes; column name suggestions

### DIFF
--- a/models/bronze/bronze_api__coin_metadata.sql
+++ b/models/bronze/bronze_api__coin_metadata.sql
@@ -64,7 +64,7 @@ SELECT
     DATA :iconUrl :: STRING AS icon_url,
     DATA :name :: STRING AS NAME,
     DATA :symbol :: STRING AS symbol,
-    DATA :id :: STRING AS id,
+    DATA :id :: STRING AS object_id,
     {{ dbt_utils.generate_surrogate_key(['coin_type']) }} AS coin_metadata_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,

--- a/models/gold/core/core__dim_tokens.sql
+++ b/models/gold/core/core__dim_tokens.sql
@@ -12,8 +12,7 @@ SELECT
     NAME,
     description,
     icon_url,
-    id,
-    {{ dbt_utils.generate_surrogate_key(['coin_type']) }} AS coin_types_id,
+    object_id,
     {{ dbt_utils.generate_surrogate_key(['coin_type']) }} AS dim_tokens_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp

--- a/models/gold/core/core__fact_changes.sql
+++ b/models/gold/core/core__fact_changes.sql
@@ -29,7 +29,7 @@ WITH base AS (
         change_value :"objectType" :: STRING AS object_type,
         change_value :"version" :: BIGINT AS version,
         change_value :"previousVersion" :: BIGINT AS previous_version,
-        change_value :"owner" :"AddressOwner" :: STRING AS object_owner
+        change_value :"owner" :"ObjectOwner" :: STRING AS object_owner,
     FROM
         {{ ref('silver__transactions') }} A,
         LATERAL FLATTEN(

--- a/models/gold/core/core__fact_changes.sql
+++ b/models/gold/core/core__fact_changes.sql
@@ -27,9 +27,9 @@ WITH base AS (
         change_value :"digest" :: STRING AS digest,
         change_value :"objectId" :: STRING AS object_id,
         change_value :"objectType" :: STRING AS object_type,
-        change_value :"version" :BIGINT AS version,
-        change_value :"previousVersion" :BIGINT AS previous_version,
-        change_value :"owner" :"ObjectOwner" :: STRING AS object_owner,
+        change_value :"version" :: BIGINT AS version,
+        change_value :"previousVersion" :: BIGINT AS previous_version,
+        change_value :"owner" :"AddressOwner" :: STRING AS object_owner
     FROM
         {{ ref('silver__transactions') }} A,
         LATERAL FLATTEN(

--- a/models/gold/core/core__fact_transaction_blocks.sql
+++ b/models/gold/core/core__fact_transaction_blocks.sql
@@ -24,16 +24,16 @@ WITH base AS (
         {# transaction_json :"transaction" :txSignatures AS tx_signatures, #}
         transaction_json :"effects": "dependencies" AS tx_dependencies,
         {# transaction_json :"effects": "gasObject" :"reference" :"digest" :: STRING AS gas_digest, #}
-        transaction_json :"effects": "gasUsed" :"computationCost" :: bigint AS gas_used_computation_cost,
+        transaction_json :"effects": "gasUsed" :"computationCost" :: bigint AS gas_used_computation_fee,
         transaction_json :"effects": "gasUsed" :"nonRefundableStorageFee" :: bigint AS gas_used_non_refundable_storage_fee,
-        transaction_json :"effects": "gasUsed" :"storageCost" :: bigint AS gas_used_storage_cost,
+        transaction_json :"effects": "gasUsed" :"storageCost" :: bigint AS gas_used_storage_fee,
         transaction_json :"effects": "gasUsed" :"storageRebate" :: bigint AS gas_used_storage_rebate,
         transaction_json :"transaction" :"data" :"gasData" :"budget" :: bigint AS gas_budget,
         transaction_json :"transaction" :"data" :"gasData" :"owner" :: STRING AS gas_owner,
         transaction_json :"transaction" :"data" :"gasData" :"price" :: bigint AS gas_price,
         {# transaction_json :"transaction" :"data" :"gasData" :"payment" AS gas_payments, #}
         (
-            gas_used_computation_cost + gas_used_storage_cost - gas_used_storage_rebate
+            gas_used_computation_fee + gas_used_storage_fee - gas_used_storage_rebate
         ) / pow(
             10,
             9
@@ -61,9 +61,9 @@ SELECT
     tx_succeeded,
     tx_error,
     tx_dependencies,
-    gas_used_computation_cost,
+    gas_used_computation_fee,
     gas_used_non_refundable_storage_fee,
-    gas_used_storage_cost,
+    gas_used_storage_fee,
     gas_used_storage_rebate,
     gas_price,
     gas_budget,

--- a/models/gold/core/gold_core.yml
+++ b/models/gold/core/gold_core.yml
@@ -196,10 +196,10 @@ models:
         data_type: VARCHAR
       - name: VERSION
         description: "{{ doc('version') }}"
-        data_type: VARIANT
+        data_type: BIGINT
       - name: PREVIOUS_VERSION
         description: "{{ doc('previous_version') }}"
-        data_type: VARIANT
+        data_type: BIGINT
       - name: OBJECT_OWNER
         description: "{{ doc('object_owner') }}"
         data_type: VARCHAR


### PR DESCRIPTION
Only 1 source JSON fix is included in this PR; everything else is cleanup.

## Fix to `core__fact_changes`
- casts to bigint for `version` and `previousVersion` had SQL typos
- also changed datatype in tests from `VARIANT` to `BIGINT`

## Consistency suggestions
### `core__dim_tokens` + `bronze_api__coin_metadata`
- the `id` column name is ambiguous. this shows up on scanners as `object_id`
- there are 2 identical surrogate keys, was this intentional?

### fact_transaction_blocks
on scanners, all gas-related costs are referred to as fees. renaming these columns aligns with scanners and is more consistent