### PR TITLE
fix amount_usd calculation

### DIFF
--- a/models/gold/defi/defi__ez_bridge_activity.sql
+++ b/models/gold/defi/defi__ez_bridge_activity.sql
@@ -62,7 +62,7 @@ SELECT
         10,
         b.decimals
     ) AS amount,
-    (amount / pow(10, b.decimals)) * C.price AS amount_usd,
+    amount * C.price AS amount_usd,
     COALESCE(
         C.token_is_verified,
         FALSE


### PR DESCRIPTION
Fix for the defective double-adjustment of `amount` ---> `amount_usd`:

```sql
select * from sui_dev.defi.ez_bridge_activity 
where tx_digest = 'EZd1tW8NwvL8utTk7W6wyU8uNkEER17bUnmCMor7hjm'
```



| TX_DIGEST                                | SYMBOL | AMOUNT_UNADJ |   AMOUNT   |     AMOUNT_USD     |
|------------------------------------------|--------|--------------|------------|--------------------|
| **OLD** EZd...hjm | USDC   | 100201369    | 100.201369 | 0.000100201369     |
| **NEW** EZd...hjm | USDC   | 100201369    | 100.201369 | 100.201369         |